### PR TITLE
Bug fix: The container should be centered

### DIFF
--- a/style.css
+++ b/style.css
@@ -8,6 +8,7 @@ div.container-fluid {
 div.container {
   display: flex;
   width: 70%;
+  justify-content: center;
   margin: auto;
 }
 


### PR DESCRIPTION
The container was still by the left, so the justify content was used to center it.